### PR TITLE
feat(mobile nav): add mobile nav in css only version

### DIFF
--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -43,7 +43,10 @@
     {{ block "main" . }}{{end}}
 
     {{ block "footer" . }}{{ partial "footer" . }}{{end}}
+
   </div>
+
+  {{ partial "mobile-nav" . }}
 
   {{ $script := .Site.Data.webpack.main }}
   {{ with $script.js }}

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -2,6 +2,9 @@
   <div class="header__wrapper">
     <div class="header__container">
       <div class="header__left">
+          <label for="mobile-nav-input" class="header__mobile-nav-trigger">
+            <span></span>
+          </label>
           <a href="{{ .Site.Home.RelPermalink }}" class="header__logo">
             <img src="/logo-skribble.svg" alt="">
             Skribble
@@ -23,3 +26,7 @@
     </div>
   </div>
 </header>
+
+<script>
+
+</script>

--- a/site/layouts/partials/intro.html
+++ b/site/layouts/partials/intro.html
@@ -22,7 +22,7 @@
       <h1>{{ .title }}</h1>
       <p>{{ .text }}</p>
     </div>
-    <picture class="hide-for-desktop">
+    <picture class="intro__image--mobile hide-for-desktop">
       <source
         type="image/webp"
         srcset="{{ .image.mobile.filename_webp }} {{ .image.mobile.width }}w, {{ .image.desktop.filename_webp }} {{ .image.desktop.width }}w"

--- a/site/layouts/partials/mobile-nav.html
+++ b/site/layouts/partials/mobile-nav.html
@@ -1,0 +1,54 @@
+<input id="mobile-nav-input" type="checkbox" class="mobile-nav__input">
+<div class="mobile-nav">
+  <div class="mobile-nav__header">
+    <label for="mobile-nav-input" class="mobile-nav__label">
+      <svg width="30px" height="30px" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
+        <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+            <circle stroke="#7E8AA1" stroke-width="2" opacity="0.5" cx="15" cy="15" r="14"></circle>
+            <g transform="translate(11.000000, 11.000000)" stroke="#65728E" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.4">
+                <path d="M8,0 L0,8"></path>
+                <path d="M8,8 L0,0"></path>
+            </g>
+        </g>
+      </svg>
+    </label>
+    <a href="{{ .Site.Home.RelPermalink }}" class="mobile-nav__logo">
+      <img src="/logo-skribble.svg" alt="">
+      Skribble
+    </a>
+  </div>
+  <div class="mobile-nav__body">
+    <nav>
+      <ul class="mobile-nav__main-nav">
+        {{ $currentPage := . }}
+        <li>
+          <a href="{{ "/" | relLangURL }}">Home</a>
+        </li>
+        {{ range.Site.Menus.main }}
+        <li>
+          <a class="{{ if eq (string (.URL | relLangURL)) $currentPage.RelPermalink }}active{{ end }}" href="{{ .URL | relLangURL }}"> {{ .Name }} </a>
+        </li>
+        {{ end }}
+      </ul>
+    </nav>
+    <nav class="mobile-nav__secondary">
+      <ul class="mobile-nav__lan-nav">
+        {{ range .Site.Languages }}
+          {{ if eq . $.Site.Language }}
+            <li><a href="#" class="active language">{{ .LanguageName }}</a></li>
+          {{ else }}
+            {{ range $.Translations }}
+            <li><a href="{{ .Permalink }}" class="">{{ .Language.LanguageName }}</a></li>
+            {{ end }}
+          {{ end }}
+        {{ end }}
+      </ul>
+      <ul class="mobile-nav__footer-nav">
+        {{ $currentPage := . }}
+        {{ range .Site.Menus.footer }}
+          <li><a class="{{ if eq (string (.URL | relLangURL)) $currentPage.RelPermalink }}active{{ end }}" href="{{ .URL }}">{{ .Name }}</a></li>
+        {{ end }}
+      </ul>
+    </nav>
+  </div>
+</div>

--- a/src/css/imports/block.scss
+++ b/src/css/imports/block.scss
@@ -3,9 +3,9 @@
   @include vertical-unit-margins;
 
   &__image {
+    max-width: 400px;
     @include min-width {
-      flex: 1 0 400px;
-      max-width: 400px;
+      flex: 0 1.5 400px;
     }
 
     img {
@@ -27,8 +27,8 @@
   }
 
   .title-subtitle {
-    max-width: 580px;
     @include min-width {
+      flex: 1 1 580px;
       padding-right: 80px;
     }
   }

--- a/src/css/imports/collapsible.scss
+++ b/src/css/imports/collapsible.scss
@@ -20,6 +20,10 @@
     cursor: pointer;
     font-weight: bold;
     color: var(--c-text-alt);
+    @include max-width {
+      padding-left: 5px;
+      padding-right: 40px;
+    }
 
     &:after,
     &:before {
@@ -31,6 +35,9 @@
       background-color: var(--c-text-alt);
       transition: all .36s cubic-bezier(.4, 0, .2, 1);
       content: '';
+      @include max-width {
+        right: 15px;
+      }
     }
 
     &:before {
@@ -71,6 +78,10 @@
     opacity: 0;
     padding: 0 85px 35px;
     transition: all .2s;
+    @include max-width {
+      padding-right: 40px;
+      padding-left: 60px;
+    }
     &:after {
       position: absolute;
       left: 0;

--- a/src/css/imports/compliance.scss
+++ b/src/css/imports/compliance.scss
@@ -1,8 +1,7 @@
 .compliance {
+  @include site-width;
   @include vertical-unit-margins;
-  max-width: 750px;
-  margin-left: auto;
-  margin-right: auto;
+  width: 750px;
 
   &__title {
     text-align: center;

--- a/src/css/imports/header.scss
+++ b/src/css/imports/header.scss
@@ -1,7 +1,9 @@
 .header {
   position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
   z-index: 100;
-  width: 100%;
   background-color: #fff;
   border-bottom: 1px solid #dadee6;
 
@@ -23,6 +25,10 @@
   &__left {
     display: flex;
     align-items: center;
+    @include max-width {
+      flex: 1 1 100%;
+      justify-content: space-between;
+    }
   }
 
   &__logo {
@@ -64,6 +70,45 @@
   &__btn {
     @include max-width {
       display: none;
+    }
+  }
+
+  &__mobile-nav-trigger {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 24px;
+    height: 24px;
+    padding: 10px;
+    margin-left: -10px;
+    margin-right: 10px;
+    box-sizing: content-box;
+    @include min-width {
+      display: none;
+    }
+
+    > span {
+        position: relative;
+        width: 24px;
+        height: 3px;
+        border-radius: 1.5px;
+        background-color: var(--c-text);
+        &:before,
+        &:after {
+        position: absolute;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        border-radius: 1.5px;
+        background-color: var(--c-text);
+        content: '';
+      }
+      &:before {
+        top: -7px;
+      }
+      &:after {
+        top: 7px;
+      }
     }
   }
 }

--- a/src/css/imports/intro.scss
+++ b/src/css/imports/intro.scss
@@ -10,7 +10,8 @@
   }
 
   .title-subtitle {
-    margin: 0 0 30px;
+    width: auto;
+    margin: 0 0 20px;
   }
 
   .btn {
@@ -21,13 +22,22 @@
   }
 
   &__image {
-    max-width: 620px;
+    @include min-width {
+      flex: 1 1.5 100%;
+    }
+
+    &--mobile {
+      display: block;
+      max-width: 400px;
+      margin-left: auto;
+      margin-right: auto;
+    }
   }
 
   &__text {
-    max-width: 595px;
     @include min-width {
-      padding: 0 80px;
+      flex: 1 1 100%;
+      padding-left: 80px;
     }
   }
 

--- a/src/css/imports/mixins.scss
+++ b/src/css/imports/mixins.scss
@@ -1,7 +1,7 @@
 @mixin site-width {
   display: block;
   width: 1400px;
-  max-width: 100vw;
+  max-width: 100%;
   padding-right: 24px;
   padding-left: 24px;
   margin-left: auto;

--- a/src/css/imports/mobile-nav.scss
+++ b/src/css/imports/mobile-nav.scss
@@ -1,0 +1,121 @@
+.mobile-nav {
+  position: fixed;
+  z-index: 200;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  transform: translateX(-100%);
+  opacity: 0.8;
+  transition: all .26s cubic-bezier(.4,.0,1,1);
+  background-color: white;
+  overflow: scroll;
+
+  a {
+    text-decoration: none;
+  }
+
+  &__logo {
+    display: flex;
+    align-items: center;
+    margin-right: 10px;
+    font-weight: bold;
+    color: var(--c-text-alt);
+    font-size: 2.4rem;
+    opacity: 0;
+    transition: all .15s cubic-bezier(.4,0,.2,1)
+  }
+
+  &__input {
+    position: fixed;
+    z-index: 100;
+    left: -100px;
+    top: 100px;
+    &:checked ~ .mobile-nav {
+      transform: translateX(0);
+      opacity: 1;
+      transition: all .26s cubic-bezier(0,.0,.2,1);
+
+      .mobile-nav__logo {
+        opacity: 1;
+        transition: all .26s .26s cubic-bezier(.4,0,.2,1)
+      }
+    }
+  }
+
+  &__header {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 64px;
+    margin-left: 24px;
+    margin-right: 24px;
+    border-bottom: 1px solid var(--c-border);
+  }
+
+  &__label {
+    padding: 10px;
+    margin-left: -10px;
+    cursor: pointer;
+
+    svg {
+      display: block;
+    }
+  }
+
+  &__body {
+    @include site-width;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    min-height: 100vh;
+    padding-top: 64px;
+  }
+
+  &__main-nav {
+    margin: 15px 0;
+    padding: 0;
+    list-style-type: none;
+
+    a {
+      display: block;
+      padding: 12px 0;
+      font-size: 2.4rem;
+      line-height: 1;
+      color: var(--c-text);
+      &.active {
+        font-weight: bold;
+        color: var(--c-text-alt);
+      }
+    }
+  }
+
+  &__secondary {
+
+    ul {
+      margin: 16px 0 0 0;
+      padding: 0 0 16px 0;
+      list-style-type: none;
+    }
+
+    a {
+      display: block;
+      padding: 6px 0;
+      font-size: 1.6rem;
+      line-height: 1;
+      color: var(--c-text);
+      &.active {
+        font-weight: bold;
+        color: var(--c-text-alt);
+      }
+    }
+  }
+
+  &__lan-nav {
+    border-bottom: 1px solid var(--c-border);
+  }
+}

--- a/src/css/imports/price-plan.scss
+++ b/src/css/imports/price-plan.scss
@@ -19,13 +19,13 @@
 
   &__description {
     padding: 17px var(--price-plan-lateral-padding) 20px;
-    border-bottom: 1px solid #D8D8D8;
     font-size: 1.8rem;
     line-height: 1.22;
   }
 
   &__details {
     padding: 13px var(--price-plan-lateral-padding) 25px;
+    border-top: 1px solid #D8D8D8;
   }
 
   &__lower {

--- a/src/css/imports/title-subtitle.scss
+++ b/src/css/imports/title-subtitle.scss
@@ -1,20 +1,21 @@
 .title-subtitle {
-  max-width: 688px;
+  width: 688px;
+  max-width: 100%;
   margin: 80px auto;
   text-align: left;
   @include max-width {
-    margin-bottom: 30px;
+    margin-top: 10px;
+    margin-bottom: 20px;
   }
 
   &.align-center {
     text-align: center;
-    // @include max-width {
-    //   text-align: left;
-    // }
   }
 
   &.is-wide {
-    max-width: none;
+    @include min-width {
+      max-width: none;
+    }
   }
 
   h1 {

--- a/src/css/imports/vars.css
+++ b/src/css/imports/vars.css
@@ -6,5 +6,5 @@
   --c-text-alt: #293d66;
   --c-border: #DADEE6;
 
-  --averta: Averta;
+  --averta: Averta, Arial, sans-serif;
 }

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -33,6 +33,7 @@
 @import 'imports/intro';
 @import 'imports/lan-nav';
 @import 'imports/maps';
+@import 'imports/mobile-nav';
 @import 'imports/newsletter';
 @import 'imports/outro';
 @import 'imports/person';
@@ -73,22 +74,31 @@ img {
 
 .main {
   flex: 1 1 100%;
+  max-width: 100vw;
   position: relative;
-  padding: 90px 50px;
+  padding: 90px 40px;
   @include max-width {
-    padding: 65px 20px;
+    padding: 65px 0;
   }
 
   &--narrow {
-    width: 100%;
-    max-width: 800px;
+    @include site-width;
+    width: 800px;
+    max-width: 100%;
     margin: 0 auto;
   }
 
   &--contact,
   &--team {
+    @include site-width;
     width: 1030px;
     max-width: 100%;
+  }
+
+  > .title-subtitle:first-child {
+    @include max-width {
+      margin-top: 40px;
+    }
   }
 }
 


### PR DESCRIPTION
Add arial and sans-serif as font-fallback that is shown before the Averta font has been loaded
(previously a serif font was shown). Fix issues with global padding on mobile.