### PR TITLE
[MRG] fix(mobile nav): set initial position to off-screen

### DIFF
--- a/src/css/imports/mobile-nav.scss
+++ b/src/css/imports/mobile-nav.scss
@@ -1,11 +1,11 @@
 .mobile-nav {
   position: fixed;
   z-index: 200;
-  left: 0;
+  left: -100%;
   top: 0;
-  right: 0;
+  right: 100%;
   bottom: 0;
-  transform: translateX(-100%);
+  transform: translateX(0);
   opacity: 0.8;
   transition: all .26s cubic-bezier(.4,.0,1,1);
   background-color: white;
@@ -32,7 +32,7 @@
     left: -100px;
     top: 100px;
     &:checked ~ .mobile-nav {
-      transform: translateX(0);
+      transform: translateX(100%);
       opacity: 1;
       transition: all .26s cubic-bezier(0,.0,.2,1);
 


### PR DESCRIPTION
Initializing with the transition of translating the navigation out of the viewport had the effect
that the navigation quickly flashed on the screen of desktop viewports when loading.