### PR TITLE
[MRG] feat(home): add try it now action for mobile on homepage

### DIFF
--- a/site/content/english/_index.md
+++ b/site/content/english/_index.md
@@ -24,7 +24,7 @@ intro:
   alt_text:
   link:
     text: Try it now
-    href: '#'
+    href: https://my.skribble.com/signup
   partner:
     image: swisscom.png
     alt_text:

--- a/site/content/german/_index.md
+++ b/site/content/german/_index.md
@@ -25,8 +25,8 @@ intro:
       width: 1356
   alt_text:
   link:
-    text: Jetzt Registrieren
-    href: '#'
+    text: Jetzt ausprobieren
+    href: https://my.skribble.com/signup?lang=de
   partner:
     image: swisscom.png
     alt_text:

--- a/site/layouts/partials/intro.html
+++ b/site/layouts/partials/intro.html
@@ -39,7 +39,7 @@
           alt="{{ .alt_text }}"
         />
       </picture>
-      <!-- <a class="btn" href="{{ .link.href }}">{{ .link.text }}</a> -->
+      <a class="btn" href="{{ .link.href }}">{{ .link.text }}</a>
       <div class="intro__partner">
         <img class="intro__partner-img" src="{{ .partner.image }}" alt="{{ .partner.alt_text }}" />
         <div class="intro__partner-text">{{ .partner.text }}</div>

--- a/src/css/imports/btn.scss
+++ b/src/css/imports/btn.scss
@@ -1,6 +1,6 @@
 .btn {
   display: inline-block;
-  height: 66px;
+  height: 60px;
   font-weight: bold;
   text-align: center;
   white-space: nowrap;
@@ -10,7 +10,7 @@
   border-radius: 3px;
   padding: 0 23px;
   font-size: 1.6rem;
-  line-height: 66px;
+  line-height: 60px;
   cursor: pointer;
   color: #fff;
   background-color: var(--c-primary);


### PR DESCRIPTION
First call to action (_try Skribble now_) was missing on mobile. A button has been added to the intro component that sits at the very top of the homepage. The button is also visible on desktop viewports.