### PR TITLE
[MRG] fix(footer): fix issue where height of mobile footer was restricted

### DIFF
--- a/src/css/imports/footer.scss
+++ b/src/css/imports/footer.scss
@@ -38,7 +38,9 @@
 
     &--stripe {
       align-items: center;
-      height: 60px;
+      @include min-width {
+        height: 60px;
+      }
     }
   }
 


### PR DESCRIPTION
Navigation is unreadable and not clickable because of the fixed height of the footer.