### PR TITLE
[MRG] fix(language switcher): make the language switcher work within the mobile nav 

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -47,7 +47,7 @@
       <div class="footer__left">
         {{ if ne "404" .Page.Kind  }}
           <nav>
-            <ul id="lang-switcher" class="lan-nav">
+            <ul class="js-lang-switcher lan-nav">
               {{ range .Site.Languages }}
                 {{ if eq . $.Site.Language }}
                   <li><a href="#" class="active language" data-lang="{{ .Lang }}">{{ .LanguageName }}</a></li>

--- a/site/layouts/partials/language-switch-js.html
+++ b/site/layouts/partials/language-switch-js.html
@@ -122,17 +122,17 @@
   // as soon as DOM is ready
   window.addEventListener('DOMContentLoaded', function(e) {
     // redirect to setLanguage if not already there
-    var activeLangEl = document.querySelector("#lang-switcher .active");
+    var activeLangEl = document.querySelector(".js-lang-switcher .active");
     if (Skribble.coveLang !== activeLangEl.dataset.lang) {
       // remember language
       Cookies.set("cove-lang", Skribble.coveLang, { expires: 365 });
       var newLocation = document.querySelector(
-        `#lang-switcher [data-lang="${Skribble.coveLang}"]`
+        `.js-lang-switcher [data-lang="${Skribble.coveLang}"]`
       );
       window.location.replace(newLocation.href);
     }
     // handle click events on lang-switcher
-    document.querySelectorAll("#lang-switcher a").forEach(function (el) {
+    document.querySelectorAll(".js-lang-switcher a").forEach(function (el) {
       el.onclick = langClicked;
     });
   })

--- a/site/layouts/partials/mobile-nav.html
+++ b/site/layouts/partials/mobile-nav.html
@@ -42,13 +42,13 @@
       </ul>
     </nav>
     <nav class="mobile-nav__secondary">
-      <ul class="mobile-nav__lan-nav">
+      <ul class="mobile-nav__lan-nav js-lang-switcher">
         {{ range .Site.Languages }}
           {{ if eq . $.Site.Language }}
-            <li><a href="#" class="active language">{{ .LanguageName }}</a></li>
+            <li><a href="#" class="active language" data-lang="{{ .Lang }}">{{ .LanguageName }}</a></li>
           {{ else }}
             {{ range $.Translations }}
-            <li><a href="{{ .Permalink }}" class="">{{ .Language.LanguageName }}</a></li>
+            <li><a href="{{ .Permalink }}" data-lang="{{ .Lang }}">{{ .Language.LanguageName }}</a></li>
             {{ end }}
           {{ end }}
         {{ end }}


### PR DESCRIPTION
Only the switcher in the footer was functional because it was picked up via an ID by javascript. Changed the query selector to target via a class, prefixed with js to reduce the probability of a naming collision.