### PR TITLE
fix(mobile): set maximum width to 100 viewport units

### DIFF
--- a/site/layouts/partials/footer-language-switcher.html
+++ b/site/layouts/partials/footer-language-switcher.html
@@ -7,16 +7,16 @@
             {{ $siteLanguages := .Site.Languages}}
             {{ $pageLang := .Page.Lang}}
             {{ range .Page.AllTranslations }}
-                {{ $translation := . }}
-                {{ range $siteLanguages }}
-                    {{ if eq $translation.Lang .Lang }}
-                      {{ if eq $pageLang .Lang}}
-                        <li><a href="{{ $translation.URL }}" class="active language" data-lang="{{.Lang}}">{{ .LanguageName }}</a></li>
-                      {{ else }}
-                        <li><a href="{{ $translation.URL }}" data-lang="{{.Lang}}">{{ .LanguageName }}</a></li>
-                      {{ end }}
-                    {{ end }}
+              {{ $translation := . }}
+              {{ range $siteLanguages }}
+                {{ if eq $translation.Lang .Lang }}
+                  {{ if eq $pageLang .Lang}}
+                    <li><a href="{{ $translation.URL }}" class="active language" data-lang="{{.Lang}}">{{ .LanguageName }}</a></li>
+                  {{ else }}
+                    <li><a href="{{ $translation.URL }}" data-lang="{{.Lang}}">{{ .LanguageName }}</a></li>
+                  {{ end }}
                 {{ end }}
+              {{ end }}
             {{ end }}
           </ul>
         </nav>

--- a/site/layouts/partials/language-switch-js.html
+++ b/site/layouts/partials/language-switch-js.html
@@ -129,7 +129,9 @@
       var newLocation = document.querySelector(
         `.js-lang-switcher [data-lang="${Skribble.coveLang}"]`
       );
-      window.location.replace(newLocation.href);
+      if (newLocation) {
+        window.location.replace(newLocation.href);
+      }
     }
     // handle click events on lang-switcher
     document.querySelectorAll(".js-lang-switcher a").forEach(function (el) {

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -80,7 +80,7 @@ img {
   &--default {
     @include site-width;
     width: 800px;
-    max-width: 100%;
+    max-width: 100vw;
     margin: 0 auto;
   }
 
@@ -88,7 +88,7 @@ img {
   &--identification {
     @include site-width;
     width: 800px;
-    max-width: 100%;
+    max-width: 100vw;
     margin: 0 auto;
   }
 
@@ -96,7 +96,7 @@ img {
   &--team {
     @include site-width;
     width: 1030px;
-    max-width: 100%;
+    max-width: 100vw;
   }
 
   > .title-subtitle:first-child {


### PR DESCRIPTION
Some pages of the Skribble website were wider than narrow viewports. This caused horizontal
scrolling on mobile phones. Fixes JS error when newLocation is undefined because of missing french pages.