### PR TITLE
[MRG] chore(site/config.yaml): set proper link

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -60,7 +60,7 @@ languages:
         text: Hol dir bei Skribble eine E-ID und leg mit dem Signieren los.
         button:
           label: Termin vereinbaren
-          href: https://help.skribble.com/meetings/patrick182/call-mit-skribble
+          href: https://help.skribble.com/meetings/patrick182/identifikation-bei-skribble
       rightSlot:
         title: Demo vereinbaren?
         text: Wir kommen gerne persönlich vorbei um dir Skribble zu zeigen.


### PR DESCRIPTION
On /de at bottom left there was a wrong link.

Closes https://app.asana.com/0/1117355270601225/1129356036141381