### PR TITLE
[MRG] styling(fonts): change font-display to 'fallback'

### DIFF
--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -8,8 +8,8 @@
   <title>{{ .Title }}</title>
 
   <style>
-    @font-face {font-family: 'Averta';src: url('/fonts/hinted-averta-regular.woff') format('woff');font-weight: normal;font-style: normal;}
-    @font-face {font-family: 'Averta';src: url('/fonts/hinted-averta-extrabold.woff') format('woff');font-weight: bold;font-style: normal;}
+    @font-face {font-family: 'Averta';font-display: fallback;src: url('/fonts/hinted-averta-regular.woff') format('woff');font-weight: normal;font-style: normal;}
+    @font-face {font-family: 'Averta';font-display: fallback;src: url('/fonts/hinted-averta-extrabold.woff') format('woff');font-weight: bold;font-style: normal;}
   </style>
 
   {{ partial "language-switch-js" }}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -80,7 +80,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  font: normal 1.8rem/1.444 $averta;
+  font: normal 1.8rem/1.444 $averta, sans-serif;
   color: $c-text;
   overflow-x: hidden;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
In order to get a better UX on slow mobile connections, we change the
Averta @font-face to use 'fallback' instead of the default which is most
likely 'block'. Additionally we set 'sans-serif' as a fallback font when
Averta loads too slow.

See also https://developers.google.com/web/updates/2016/02/font-display

Closes https://app.asana.com/0/995964219886332/1118204062378468