### PR TITLE
[WIP] chore(baseof.html): remove Hubspot tracking code

### DIFF
--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -66,8 +66,6 @@
   {{ with $script.js }}
     <script src="{{ relURL . }}"></script>
   {{ end }}
-
-  <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/5051692.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
This is to show the difference of our page speed analytics when the
Hubspot tracking is disabled.