### PR TITLE
[MRG] Typo, link, order corrections

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -96,17 +96,18 @@ languages:
       meta:
         - name: Datenschutzbestimmungen
           url: /de/datenschutz/
-          weight: 10
-        - name: Impressum
-          url: /de/impressum/
-          weight: 15
-      footermobile:
-        - name: Impressum
-          url: /de/impressum/
           weight: 5
+        - name: Impressum
+          url: /de/impressum/
+          weight: 10
+      footermobile:
         - name: Datenschutzbestimmungen
           url: /de/datenschutz/
+          weight: 5
+        - name: Impressum
+          url: /de/impressum/
           weight: 10
+  
     header:
       login:
         label: Login
@@ -239,12 +240,13 @@ languages:
           url: /imprint/
           weight: 15
       footermobile:
-        - name: Imprint
-          url: /imprint/
-          weight: 5
         - name: Privacy Policy
           url: /privacy/
+          weight: 5
+        - name: Imprint
+          url: /imprint/
           weight: 10
+
     header:
       login:
         label: Login
@@ -378,12 +380,13 @@ languages:
           url: /fr/impressum/
           weight: 15
       footermobile:
-        - name: Impressum
-          url: /fr/impressum/
-          weight: 5
         - name: Politique de Confidentialité
           url: /fr/politique-de-confidentialite/
+          weight: 5
+        - name: Impressum
+          url: /fr/impressum/
           weight: 10
+
     header:
       login:
         label: Login

--- a/site/content/english/privacy.md
+++ b/site/content/english/privacy.md
@@ -15,7 +15,7 @@ description: Privacy policy meta description
 
 This page informs you of our policies regarding the collection, use and disclosure of personal data when you use our Service and the choices you have associated with that data.
 
-We use your data to provide and improve the Service. By using the Service, you agree to the collection and use of information in accordance with this policy. Unless otherwise defined in this Privacy Policy, the terms used in this Privacy Policy have the same meanings as in our Terms and Conditions, accessible from <a href="https://www.skribble.com" target="_blank">www.skribble.com</a>.
+We use your data to provide and improve the Service. By using the Service, you agree to the collection and use of information in accordance with this policy. Unless otherwise defined in this Privacy Policy, the terms used in this Privacy Policy have the same meanings as in our Terms and Conditions, accessible from <a href="https://www.skribble.com/gtc/" target="_blank">www.skribble.com/gtc/</a>.
 
 ## Definitions
 

--- a/site/content/english/signaturestandards.md
+++ b/site/content/english/signaturestandards.md
@@ -35,7 +35,7 @@ For signing with QES on Skribble, a prior identity check in personal contact or 
 
 {{< testimonial "testimonial/or-logo-en-160w.png" "Article 14 paragraph 2bis of the Swiss Code of Obligations (OR)" >}}
 
-"An authenticated electronic signature combined with an authenticated time stamp within the meaning of the Federal Act of 18 March 20161 on Electronic Signatures is deemed equivalent to a handwritten signature, subject to any statutory or contractual provision to the contrary."
+"An authenticated electronic signature combined with an authenticated time stamp within the meaning of the Federal Act of 18 March 2016 on Electronic Signatures is deemed equivalent to a handwritten signature, subject to any statutory or contractual provision to the contrary."
 {{< /testimonial >}}
 
 [//]: # (--------------------------------------------------------------------------------------------------------------)

--- a/site/content/french/privacy.md
+++ b/site/content/french/privacy.md
@@ -15,7 +15,7 @@ description: Politique de Confidentialité méta-description
 
 Cette page vous explique nos politiques en matière de collecte, d'utilisation et de communication des données à caractère personnel lorsque vous utilisez notre Service ainsi que les choix qui s'offrent à vous en ce qui concerne ces données.
 
-Nous utilisons vos données pour fournir et améliorer le Service. En utilisant le Service, vous consentez à la collecte et à l'utilisation d'informations conformément à la présente politique. Sauf définition contraire dans la présente Politique de Confidentialité, les termes utilisés dans la présente Politique de Confidentialité ont la même signification que dans nos Conditions Générales qui sont disponibles sur <a href="https://www.skribble.com" target="_blank">www.skribble.com</a>.
+Nous utilisons vos données pour fournir et améliorer le Service. En utilisant le Service, vous consentez à la collecte et à l'utilisation d'informations conformément à la présente politique. Sauf définition contraire dans la présente Politique de Confidentialité, les termes utilisés dans la présente Politique de Confidentialité ont la même signification que dans nos Conditions Générales qui sont disponibles sur <a href="https://www.skribble.com/fr/cg/" target="_blank">www.skribble.com/fr/cg/</a>.
 
 ## Définitions
 

--- a/site/content/german/privacy.md
+++ b/site/content/german/privacy.md
@@ -15,7 +15,7 @@ Skribble AG ("wir", "uns", "unser" usw.) betreibt die Website <a href="https://w
 
 Diese Seite enthält Informationen zu der Art und Weise, auf welche wir personenbezogene Daten erfassen, nutzen und offenlegen, wenn Sie unseren Dienst nutzen, sowie zu den Optionen, die Ihnen im Zusammenhang mit diesen Daten zur Verfügung stehen.
 
-Wir nutzen Ihre Daten zur Bereitstellung und Verbesserung unseres Dienstes. Durch Inanspruchnahme des Dienstes erklären Sie sich mit der Erfassung und Nutzung von Daten durch uns nach Maßgabe dieser Richtlinie einverstanden. Soweit in dieser Datenschutz-Richtlinie nicht jeweils etwas anderes angegeben ist, kommt den in dieser Datenschutz-Richtlinie vorkommenden Begriffen jeweils dieselbe Bedeutung zu, die diesen in unseren Allgemeinen Geschäftsbedingungen (Terms and Conditions) (abrufbar über die <a href="https://www.skribble.com" target="_blank">www.skribble.com</a> zugewiesen wurde.
+Wir nutzen Ihre Daten zur Bereitstellung und Verbesserung unseres Dienstes. Durch Inanspruchnahme des Dienstes erklären Sie sich mit der Erfassung und Nutzung von Daten durch uns nach Maßgabe dieser Richtlinie einverstanden. Soweit in dieser Datenschutz-Richtlinie nicht jeweils etwas anderes angegeben ist, kommt den in dieser Datenschutz-Richtlinie vorkommenden Begriffen jeweils dieselbe Bedeutung zu, die diesen in unseren Allgemeinen Geschäftsbedingungen (Terms and Conditions) (abrufbar über die <a href="https://www.skribble.com/de/agb/" target="_blank">www.skribble.com/de/agb/</a> zugewiesen wurde.
 
 ## Begriffsbestimmungen
 


### PR DESCRIPTION
 Changed typo in year (20161) - OR article EN on the signature standard page