### PR TITLE
[MRG] feat(Footer links): Make external links open in new window

### DIFF
--- a/site/layouts/partials/footer-navigation.html
+++ b/site/layouts/partials/footer-navigation.html
@@ -7,7 +7,7 @@
           {{ $currentPage := . }}
           {{ range.Site.Menus.footer1 }}
             <li>
-              <a class="{{ if eq (string .URL) $currentPage.RelPermalink }}active{{ end }}" href="{{ .URL }}"> {{ .Name }} </a>
+              <a class="{{ if eq (string .URL) $currentPage.RelPermalink }}active{{ end }}" href="{{ .URL }}" {{ if in .URL "http" }} target="_blank" {{ end }}> {{ .Name }} </a>
             </li>
           {{ end }}
         </ul>
@@ -18,7 +18,7 @@
           {{ $currentPage := . }}
           {{ range.Site.Menus.footer2 }}
             <li>
-              <a class="{{ if eq (string .URL) $currentPage.RelPermalink }}active{{ end }}" href="{{ .URL }}"> {{ .Name }} </a>
+              <a class="{{ if eq (string .URL) $currentPage.RelPermalink }}active{{ end }}" href="{{ .URL }}" {{ if in .URL "http" }} target="_blank" {{ end }}> {{ .Name }} </a>
             </li>
           {{ end }}
         </ul>
@@ -29,7 +29,7 @@
           {{ $currentPage := . }}
           {{ range.Site.Menus.footer3 }}
             <li>
-              <a class="{{ if eq (string .URL) $currentPage.RelPermalink }}active{{ end }}" href="{{ .URL }}"> {{ .Name }} </a>
+              <a class="{{ if eq (string .URL) $currentPage.RelPermalink }}active{{ end }}" href="{{ .URL }}" {{ if in .URL "http" }} target="_blank" {{ end }}> {{ .Name }} </a>
             </li>
           {{ end }}
         </ul>
@@ -40,7 +40,7 @@
           {{ $currentPage := . }}
           {{ range.Site.Menus.footer4 }}
             <li>
-              <a class="{{ if eq (string .URL) $currentPage.RelPermalink }}active{{ end }}" href="{{ .URL }}"> {{ .Name }} </a>
+              <a class="{{ if eq (string .URL) $currentPage.RelPermalink }}active{{ end }}" href="{{ .URL }}" {{ if in .URL "http" }} target="_blank" {{ end }}> {{ .Name }} </a>
             </li>
           {{ end }}
         </ul>


### PR DESCRIPTION
Because of Hugo restrictions on Menu fields definition it is not possible to have manually set target fields with our current code.

However, it's quite straightforward to make external links automatically have `target="_blank"`.

This should solve https://app.asana.com/0/995964219886332/1157719763255473/f