### PR TITLE
[MRG] feat(Open graph): Add current permalink as og url

### DIFF
--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -36,7 +36,7 @@ g.type='text/javascript'; g.async=true; g.defer=true; g.src='https://analytics.s
   <meta property="og:title" content="{{ .Title }}">
 
   <meta property="og:description" content="{{ .Description }}">
-  <meta property="og:url" content="https://www.skribble.com/">
+  <meta property="og:url" content="https://www.skribble.com{{ .Permalink }}">
   <meta property="og:site_name" content="Skribble">
   <!-- use open graph image from pages, or if undefined use og-skribble -->
   {{ if .Params.og_image }}


### PR DESCRIPTION
Before, it was static: www.skribble.com

This PR changes the open graph url meta tag to point to the url of the page you're currently on. It should prevent shared urls in LinkedIn to be redirect to the Skribble home page.