### PR TITLE
[MRG] feat(Cookie consent improvements): Functional and styling improvements

### DIFF
--- a/site/static/cookieconsent/config.js
+++ b/site/static/cookieconsent/config.js
@@ -11,11 +11,11 @@ var klaroConfig = {
 
   // How Klaro should store the user's preferences. It can be either 'cookie'
   // (the default) or 'localStorage'.
-  storageMethod: "localStorage",
+  storageMethod: "cookie",
 
   // You can customize the name of the cookie that Klaro uses for storing
   // user consent decisions. If undefined, Klaro will use 'klaro'.
-  cookieName: "klaro",
+  cookieName: "klaroCookiePreferences",
 
   // You can also set a custom expiration time for the Klaro cookie.
   // By default, it will expire after 120 days.
@@ -24,7 +24,7 @@ var klaroConfig = {
   // You can change to cookie domain for the consent manager itself.
   // Use this if you want to get consent once for multiple matching domains.
   // If undefined, Klaro will use the current domain.
-  //cookieDomain: '.github.com',
+  cookieDomain: '.skribble.com',
 
   // Put a link to your privacy policy here (relative or absolute).
   privacyPolicy: {
@@ -273,6 +273,14 @@ var klaroConfig = {
       name: "matomo",
       title: "Matomo",
       purposes: ["analytics"],
+    },
+    {	
+      name: "klaro",	
+      title: "Klaro",	
+      purposes: ["preferences"],	
+      // If "required" is set to true, Klaro will not allow this app to	
+      // be disabled by the user.	
+      required: true,	
     },
   ],
 };

--- a/site/static/cookieconsent/config.js
+++ b/site/static/cookieconsent/config.js
@@ -280,6 +280,7 @@ var klaroConfig = {
       purposes: ["preferences"],	
       // If "required" is set to true, Klaro will not allow this app to	
       // be disabled by the user.	
+      default: true,
       required: true,	
     },
   ],

--- a/site/static/cookieconsent/config.js
+++ b/site/static/cookieconsent/config.js
@@ -11,7 +11,7 @@ var klaroConfig = {
 
   // How Klaro should store the user's preferences. It can be either 'cookie'
   // (the default) or 'localStorage'.
-  storageMethod: "cookie",
+  storageMethod: "localStorage",
 
   // You can customize the name of the cookie that Klaro uses for storing
   // user consent decisions. If undefined, Klaro will use 'klaro'.
@@ -43,10 +43,10 @@ var klaroConfig = {
 
   // Show "accept all" to accept all apps instead of "ok" that only accepts
   // required and "default: true" apps
-  acceptAll: false,
+  acceptAll: true,
 
   // replace "decline" with cookie manager modal
-  hideDeclineAll: false,
+  hideDeclineAll: true,
 
   // You can define the UI language directly here. If undefined, Klaro will
   // use the value given in the global "lang" variable. If that does
@@ -154,7 +154,7 @@ var klaroConfig = {
       //   save: "Save",
       decline: "Refuser",
       //   close: "Close",
-      //   acceptAll: "Accept all",
+      acceptAll: "Accept tous",
       acceptSelected: "Accepter la sélection",
       //   app: {
       //     disableAll: {
@@ -218,7 +218,7 @@ var klaroConfig = {
       //   save: "Save",
       decline: "Ablehnen",
       //   close: "Close",
-      //   acceptAll: "Accept all",
+      acceptAll: "Allen akzeptieren",
       acceptSelected: "Auswahl akzeptieren",
       //   app: {
       //     disableAll: {
@@ -264,29 +264,15 @@ var klaroConfig = {
       // Each app should have a unique (and short) name.
       name: "hubspot",
       // The title of you app as listed in the consent modal.
-      title: "Hubspot, Facebook, Bing, Cloudflare",
+      title: "Hubspot, Google Tag Manager, Facebook, Bing, Cloudflare",
       // The purpose(s) of this app. Will be listed on the consent notice.
       // Do not forget to add translations for all purposes you list here.
       purposes: ["advertising", "analytics", "livechat", "security"],
-      // If "default" is set to true, the app will be enabled by default
-      // Overwrites global "default" setting.
-      // We recommend leaving this to "false" for apps that collect
-      // personal information.
-      default: true,
     },
     {
       name: "matomo",
       title: "Matomo",
       purposes: ["analytics"],
-      default: true,
-    },
-    {
-      name: "klaro",
-      title: "Klaro",
-      purposes: ["preferences"],
-      // If "required" is set to true, Klaro will not allow this app to
-      // be disabled by the user.
-      required: true,
     },
   ],
 };

--- a/site/static/cookieconsent/config.js
+++ b/site/static/cookieconsent/config.js
@@ -15,7 +15,7 @@ var klaroConfig = {
 
   // You can customize the name of the cookie that Klaro uses for storing
   // user consent decisions. If undefined, Klaro will use 'klaro'.
-  cookieName: "klaroCookiePreferences",
+  cookieName: "klaro",
 
   // You can also set a custom expiration time for the Klaro cookie.
   // By default, it will expire after 120 days.

--- a/site/static/cookieconsent/config.js
+++ b/site/static/cookieconsent/config.js
@@ -218,7 +218,7 @@ var klaroConfig = {
       //   save: "Save",
       decline: "Ablehnen",
       //   close: "Close",
-      acceptAll: "Allen akzeptieren",
+      acceptAll: "Alle akzeptieren",
       acceptSelected: "Auswahl akzeptieren",
       //   app: {
       //     disableAll: {

--- a/site/static/cookieconsent/config.js
+++ b/site/static/cookieconsent/config.js
@@ -7,7 +7,7 @@
 var klaroConfig = {
   // You can customize the ID of the DIV element that Klaro will create
   // when starting up. If undefined, Klaro will use 'klaro'.
-  elementID: "klaro",
+  elementID: "klaro-skribble",
 
   // How Klaro should store the user's preferences. It can be either 'cookie'
   // (the default) or 'localStorage'.

--- a/site/static/cookieconsent/config.js
+++ b/site/static/cookieconsent/config.js
@@ -107,7 +107,7 @@ var klaroConfig = {
         purposes: "Purposes",
         purpose: "Purpose",
       },
-      poweredBy: "Powered by Klaro!",
+      poweredBy: "",
       matomo: {
         description: "Collects visitor statistics",
       },
@@ -172,7 +172,7 @@ var klaroConfig = {
       //     purposes: "Purposes",
       //     purpose: "Purpose",
       //   },
-      //   poweredBy: "Powered by Klaro!",
+      poweredBy: "",
       matomo: {
         description: "Collecte de statistiques sur les visiteurs",
       },
@@ -236,7 +236,7 @@ var klaroConfig = {
       //     purposes: "Purposes",
       //     purpose: "Purpose",
       //   },
-      //   poweredBy: "Powered by Klaro!",
+      poweredBy: "",
       matomo: {
         description: "Sammeln von Besucherstatistiken",
       },

--- a/site/static/cookieconsent/config.js
+++ b/site/static/cookieconsent/config.js
@@ -154,7 +154,7 @@ var klaroConfig = {
       //   save: "Save",
       decline: "Refuser",
       //   close: "Close",
-      acceptAll: "Accept tous",
+      acceptAll: "Accepter tous",
       acceptSelected: "Accepter la sélection",
       //   app: {
       //     disableAll: {

--- a/src/css/imports/cookie-consent.scss
+++ b/src/css/imports/cookie-consent.scss
@@ -29,6 +29,9 @@
     }
 
     .cm-app-input:checked+.cm-app-label .slider {
+      background-color: #60718e !important
+    }
+    .cm-app-input.required:checked+.cm-list-label .slider {
       background-color: #006df2 !important
     }
   }

--- a/src/css/imports/cookie-consent.scss
+++ b/src/css/imports/cookie-consent.scss
@@ -31,8 +31,10 @@
     .cm-app-input:checked+.cm-app-label .slider {
       background-color: #006df2 !important
     }
-    .cm-app-input.required:checked+.cm-list-label .slider {
-      background-color: #60718e !important
+    .cm-app-input.required:checked+.cm-app-label .slider {
+      background-color: #60718e !important;
+      opacity: 0.6 !important
+    
     }
   }
 }

--- a/src/css/imports/cookie-consent.scss
+++ b/src/css/imports/cookie-consent.scss
@@ -29,10 +29,10 @@
     }
 
     .cm-app-input:checked+.cm-app-label .slider {
-      background-color: #60718e !important
+      background-color: #006df2 !important
     }
     .cm-app-input.required:checked+.cm-list-label .slider {
-      background-color: #006df2 !important
+      background-color: #60718e !important
     }
   }
 }

--- a/src/css/imports/cookie-consent.scss
+++ b/src/css/imports/cookie-consent.scss
@@ -1,39 +1,39 @@
-.klaro {
+#klaro-skribble {
   .cm-btn {
-    border-radius: 3px !important;
-    padding: 8px 12px !important;
+    border-radius: 3px;
+    padding: 8px 12px;
   }
 
   .cookie-notice {
     a {
-      color: white !important
+      color: white
     }
     
     .cm-btn {
-      background: #006df2 !important;
+      background: #006df2;
     }
   }
 
   .cookie-modal {
     a {
-      color: #006df2 !important
+      color: #006df2
     }
 
     .cm-btn-accept-all {
-      background: #006df2 !important
+      background: #006df2
       
     }
 
     .cm-btn-info {
-      background: #888888 !important
+      background: #888888
     }
 
     .cm-app-input:checked+.cm-app-label .slider {
-      background-color: #006df2 !important
+      background-color: #006df2
     }
     .cm-app-input.required:checked+.cm-app-label .slider {
-      background-color: #60718e !important;
-      opacity: 0.6 !important
+      background-color: #60718e;
+      opacity: 0.6
     
     }
   }

--- a/src/css/imports/cookie-consent.scss
+++ b/src/css/imports/cookie-consent.scss
@@ -25,7 +25,11 @@
     }
 
     .cm-btn-info {
-      background: #60718e !important
+      background: #888888 !important
+    }
+
+    .cm-app-input:checked+.cm-app-label .slider {
+      background-color: #006df2 !important
     }
   }
 }

--- a/src/css/imports/cookie-consent.scss
+++ b/src/css/imports/cookie-consent.scss
@@ -1,0 +1,31 @@
+.klaro {
+  .cm-btn {
+    border-radius: 3px !important;
+    padding: 8px 12px !important;
+  }
+
+  .cookie-notice {
+    a {
+      color: white !important
+    }
+    
+    .cm-btn {
+      background: #006df2 !important;
+    }
+  }
+
+  .cookie-modal {
+    a {
+      color: #006df2 !important
+    }
+
+    .cm-btn-accept-all {
+      background: #006df2 !important
+      
+    }
+
+    .cm-btn-info {
+      background: #60718e !important
+    }
+  }
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -14,6 +14,7 @@
 @import 'imports/container';
 @import 'imports/contact';
 @import 'imports/content';
+@import 'imports/cookie-consent';
 @import 'imports/cookie-resetter';
 @import 'imports/cta';
 @import 'imports/cta-group';


### PR DESCRIPTION
- ~~Klaro preferences moved to localStorage~~
- Klaro preferences moved to a cookie with domain `.skribble.com` so that they can be accessed by Wave (by default it would give the domain `www.skribble.com` to the cookie)
- Small notification only shows buttons "Accept All" and customize
- When you customize, cookies are disabled by default
- Removes "Powered by Klaro"
- Adds mention of Google Tag Manager (which Till will introduce via Hubspot)
- Improves styling