### PR TITLE
[MRG] fix(Cookie consent reset): Fixes cookie consent resetting

### DIFF
--- a/site/layouts/shortcodes/cookie-resetter.html
+++ b/site/layouts/shortcodes/cookie-resetter.html
@@ -1,5 +1,5 @@
 <div class="cookie-resetter">
-    <p><a href="" onClick="deleteAllCookies()">{{ .Get "text" }}</a></p>
+    <p><a href="" onClick="deleteAllCookies();location.reload()">{{ .Get "text" }}</a></p>
 </div>
 
 <script>

--- a/site/layouts/shortcodes/cookie-resetter.html
+++ b/site/layouts/shortcodes/cookie-resetter.html
@@ -1,3 +1,22 @@
 <div class="cookie-resetter">
-    <p><a href="" onClick="klaro.getManager().resetConsent();location.reload()">{{ .Get "text" }}</a></p>
+    <p><a href="" onClick="deleteAllCookies()">{{ .Get "text" }}</a></p>
 </div>
+
+<script>
+function deleteAllCookies() {
+    var cookies = document.cookie.split("; ");
+    for (var c = 0; c < cookies.length; c++) {
+        var d = window.location.hostname.split(".");
+        while (d.length > 0) {
+            var cookieBase = encodeURIComponent(cookies[c].split(";")[0].split("=")[0]) + '=; expires=Thu, 01-Jan-1970 00:00:01 GMT; domain=' + d.join('.') + ' ;path=';
+            var p = location.pathname.split('/');
+            document.cookie = cookieBase + '/';
+            while (p.length > 0) {
+                document.cookie = cookieBase + p.join('/');
+                p.pop();
+            };
+            d.shift();
+        }
+    }
+};
+</script>


### PR DESCRIPTION
The built in function from klaro (our cookie consent library) to reset cookies doesn't seem play well with explicitly defined domains.

This PR replaces that function with a "brute force" deletion of all cookies currently accessible to the browser window.

Does not mess with the only cookie which is really relevant to safeguard in our cookie flow. This would be `x-access-token` from Wave. It won't touch that one, since it has domain `my.skribble.com` and not `.skribble.com`. So, it's not accesible.

Unfortunately it can only be fully tested once it reaches production.