### PR TITLE
chore(aliases): remove unnecessary aliases from GTC and ToU

### DIFF
--- a/site/content/english/gtc-v2020-08-19.md
+++ b/site/content/english/gtc-v2020-08-19.md
@@ -3,7 +3,6 @@ title: General Terms and Conditions (GTC) of Skribble
 slug: gtc
 aliases:
   - gtc/archive/20200819
-  - gtc-v2020-08-19
 draft: false
 description: General Terms and Conditions (GTC) (2020-08-19)
 ---

--- a/site/content/english/terms-of-use-v2020-08-19.md
+++ b/site/content/english/terms-of-use-v2020-08-19.md
@@ -3,7 +3,6 @@ title: Terms of use
 slug: terms-of-use
 aliases:
   - terms-of-use/archive/20200819
-  - terms-of-use-v2020-08-19
 draft: false
 description: Terms of Use for System Users of Skribble (2020-08-19)
 ---

--- a/site/content/french/gtc-v2020-08-19.md
+++ b/site/content/french/gtc-v2020-08-19.md
@@ -3,7 +3,6 @@ title: Conditions Générales (CG) de Skribble
 slug: cg
 aliases:
   - cg/archives/20200819
-  - cg-v2020-08-19
 draft: false
 description: Conditions Générales (CG) (2020-08-19)
 ---

--- a/site/content/french/terms-of-use-v2020-08-19.md
+++ b/site/content/french/terms-of-use-v2020-08-19.md
@@ -3,7 +3,6 @@ title: Conditions d'utilisation
 slug: conditions-dutilisation
 aliases:
   - conditions-dutilisation/archives/20200819
-  - conditions-dutilisation-v2020-08-19
 draft: false
 description: Conditions d'utilisation pour les Utilisateurs du Système de Skribble (2020-08-19)
 ---

--- a/site/content/german/gtc-v2020-08-19.md
+++ b/site/content/german/gtc-v2020-08-19.md
@@ -3,7 +3,6 @@ title: Allgemeine Geschäftsbedingungen (AGB) von Skribble
 slug: agb
 aliases:
   - agb/archiv/20200819
-  - agb-v2020-08-19
 draft: false
 description: Allgemeine Geschäftsbedingungen (AGB) (2020-08-19)
 ---

--- a/site/content/german/terms-of-use-v2020-08-19.md
+++ b/site/content/german/terms-of-use-v2020-08-19.md
@@ -3,7 +3,6 @@ title: Nutzungsbedingungen
 slug: nutzungsbedingungen
 aliases:
   - nutzungsbedingungen/archiv/20200819
-  - nutzungsbedingungen-v2020-08-19
 draft: false
 description: Nutzungsbedingungen für Systemnutzer von Skribble (2020-08-19)
 ---


### PR DESCRIPTION
They were introduced as a copy-paste leftover from older versions which
used to use that URL scheme. But not anymore.

Closes https://app.asana.com/0/1191332220899194/1189770700812225