### PR TITLE
chore(privacy policy): adapt date to actual publication date

### DIFF
--- a/site/content/english/privacy-archive.md
+++ b/site/content/english/privacy-archive.md
@@ -9,7 +9,7 @@ description: Privacy policy archive
 {{% markdown %}}
 # Privacy Policy Archive
 
-* [Effective date: 19 August 2020 (current)](/privacy/archive/20200819)
+* [Effective date: 17 September 2020 (current)](/privacy/archive/20200917)
 * [Effective date: 22 October 2019](/privacy/archive/20191022)
 * [Effective date: 18 October 2018](/privacy/archive/20181018)
 

--- a/site/content/english/privacy-v2020-09-17.md
+++ b/site/content/english/privacy-v2020-09-17.md
@@ -2,9 +2,9 @@
 title: Privacy Policy
 slug: privacy
 aliases:
-  - privacy/archive/20200819
+  - privacy/archive/20200917
 draft: false
-description: Skribble's Privacy Policy (2020-08-19)
+description: Skribble's Privacy Policy (2020-09-17)
 ---
 
 {{< content top=16 width=narrow >}}
@@ -13,7 +13,7 @@ description: Skribble's Privacy Policy (2020-08-19)
 
 [Archived versions](/privacy/archive)
 
-<small>(Version 2020.08.19)</small>
+<small>(Version 2020.09.17)</small>
 
 The data controller for the purpose of data protection laws, especially the EU General Data Protection Regulation (GDPR), is:
 

--- a/site/content/french/privacy-archive.md
+++ b/site/content/french/privacy-archive.md
@@ -9,7 +9,7 @@ description: Archive Politiques de Confidentialité
 {{% markdown %}}
 # Archive Politiques de Confidentialité
 
-* [À compter du 19 août 2020 (actuellement en vigueur)](/fr/politique-de-confidentialite/archives/20200819)
+* [À compter du 17 septembre 2020 (actuellement en vigueur)](/fr/politique-de-confidentialite/archives/20200917)
 * [À compter du 22 octobre 2019](/fr/politique-de-confidentialite/archives/20191022)
 * [À compter du 18 octobre 2018](/fr/politique-de-confidentialite/archives/20181018)
 

--- a/site/content/french/privacy-v2020-09-17.md
+++ b/site/content/french/privacy-v2020-09-17.md
@@ -2,9 +2,9 @@
 title: Politique de Confidentialité
 slug: politique-de-confidentialite
 aliases:
-  - politique-de-confidentialite/archives/20200819
+  - politique-de-confidentialite/archives/20200917
 draft: false
-description: Politique de Confidentialité de Skribble (2020-08-19)
+description: Politique de Confidentialité de Skribble (2020-09-17)
 ---
 
 {{< content top=16 width=narrow >}}
@@ -13,7 +13,7 @@ description: Politique de Confidentialité de Skribble (2020-08-19)
 
 [Versions archivées](/fr/politique-de-confidentialite/archives)
 
-<small>(Version 2020.08.19)</small>
+<small>(Version 2020.09.17)</small>
 
 Le responsable du traitement au sens de la loi sur la protection des données et, en particulier, du Règlement général sur la protection des données de l’Union européenne (RGPD) est:
 

--- a/site/content/german/privacy-archive.md
+++ b/site/content/german/privacy-archive.md
@@ -9,7 +9,7 @@ description: Archiv Datenschutzbestimmungen
 {{% markdown %}}
 # Archiv Datenschutzbestimmungen
 
-* [Wirksam ab: 19. August 2020 (aktuell)](/de/datenschutz/archiv/20200819)
+* [Wirksam ab: 17. September 2020 (aktuell)](/de/datenschutz/archiv/20200917)
 * [Wirksam ab: 22. Oktober 2019](/de/datenschutz/archiv/20191022)
 * [Wirksam ab: 18. Oktober 2018](/de/datenschutz/archiv/20181018)
 

--- a/site/content/german/privacy-v2020-09-17.md
+++ b/site/content/german/privacy-v2020-09-17.md
@@ -2,9 +2,9 @@
 title: Datenschutzbestimmungen
 slug: datenschutz
 aliases:
-  - datenschutz/archiv/20200819
+  - datenschutz/archiv/20200917
 draft: false
-description: Datenschutzbestimmungen von Skribble (2020-08-19)
+description: Datenschutzbestimmungen von Skribble (2020-09-17)
 ---
 
 {{< content top=16 width=narrow >}}
@@ -13,7 +13,7 @@ description: Datenschutzbestimmungen von Skribble (2020-08-19)
 
 [Archivierte Versionen](/de/datenschutz/archiv)
 
-<small>(Version 19.08.2020)</small>
+<small>(Version 2020.09.17)</small>
 
 Verantwortliche Stelle im Sinne der Datenschutzgesetze, insbesondere der EU-Datenschutz-Grundverordnung (DSGVO), ist:
 


### PR DESCRIPTION
The privacy policy took a bit longer to be finalised and went online on
the Sep 17 2020.