### PR TITLE
feat(intro): Reduce whitespace between list items

### DIFF
--- a/src/css/imports/intro.scss
+++ b/src/css/imports/intro.scss
@@ -52,6 +52,14 @@
     + .hide-for-mobile {
       padding-right: 0;
     }
+
+    p + ul {
+      margin-top: -18px;
+    }
+
+    li {
+      margin: 2px 0 3px;
+    }
   }
 
   .hide-for-mobile {


### PR DESCRIPTION
This PR reduces list item margins inside of the intro component. The intro component is only used on the home page and 2 hidden pages. It has no effect as there are no lists used within intro. The PR prepares the styling for lists appearing in the PRs #463 and #475.