### PR TITLE
fix(site/config.yaml): fix broken german helpcenter link in footer

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -152,7 +152,7 @@ languages:
           url: https://news.skribble.com
           weight: 5
         - name: Help-Center
-          url: https://help.skribble.com/deutsch
+          url: https://help.skribble.com/de/deutsch
           weight: 10
         - name: API-Ressource
           url: https://api-doc.skribble.com/
@@ -376,7 +376,7 @@ languages:
           url: https://news.skribble.com
           weight: 5
         - name: Help-Center
-          url: https://help.skribble.com/english
+          url: https://help.skribble.com/de/english
           weight: 10
         - name: API resource
           url: https://api-doc.skribble.com/
@@ -589,7 +589,7 @@ languages:
           url: https://news.skribble.com
           weight: 5
         - name: Centre d'assistance
-          url: https://help.skribble.com/francais
+          url: https://help.skribble.com/de/francais
           weight: 10
         - name: API Ressource
           url: https://api-doc.skribble.com/


### PR DESCRIPTION
Apparently our helpcenter uses `/de` in the language-specific start
pages. For some reason `/francais` and `/english` are properly
redirected whereas `/deutsch` leads to a 404.

Closes https://app.asana.com/0/1117355270601225/1199388812156205