### PR TITLE
Add archived notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # cove
 🌅 Skribble **co**rporate **ve**bsite
 
+🚧🏚 This repository has been archived. skribble.com is now deployed from https://github.com/BlockSigner/covefe. Please make your changes there.
+
 ## Status
 Deploy:
 [![Netlify Status](https://api.netlify.com/api/v1/badges/7d00ef7a-5c8b-4b90-912f-355470b7d23c/deploy-status)](https://app.netlify.com/sites/skribble/deploys)


### PR DESCRIPTION
Adds a note to the README to let people know that this repo has been archived. If we merge this we should also click "archive" in the [settings](https://github.com/BlockSigner/cove/settings) (down in the danger zone) of this repo. Which should make it hard to open a PR or edit things without noticing.